### PR TITLE
Increase title font size

### DIFF
--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -87,6 +87,8 @@ local tsLegend = tsOptions.legend;
         ),
       ) +
       stOptions.withTextMode('value_and_name') +
+      stOptions.text.withTitleSize(18) +
+      stOptions.text.withValueSize(18) +
       stOptions.withColorMode('background') +
       stOptions.reduceOptions.withCalcs(['lastNotNull']) +
       stStandardOptions.withUnit('short') +


### PR DESCRIPTION
Status map panel has too small titles (actual valuable instance names), if you have over a dozen of blackbox checks. Even viewing the panel full screen (press 'V') doesn't help.

I found providing fixed title size of 18 to be optimal to actually see instance names no matter how many you have.