### PR TITLE
Aggregate queries on the dashboard.

### DIFF
--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -533,7 +533,7 @@ local tsLegend = tsOptions.legend;
 
     local probeHttpDurationQuery = |||
       sum by (instance) (
-        avg by (phase,intance) (
+        avg by (phase,instance) (
           probe_http_duration_seconds{
             job=~"$job",
             instance=~"$instance"

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -532,8 +532,8 @@ local tsLegend = tsOptions.legend;
       stOptions.reduceOptions.withCalcs(['mean']),
 
     local probeHttpDurationQuery = |||
-      avg by (instance) (
-        sum without (phase) (
+      sum by (instance) (
+        avg by (phase,intance) (
           probe_http_duration_seconds{
             job=~"$job",
             instance=~"$instance"

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -68,9 +68,9 @@ local tsLegend = tsOptions.legend;
     ],
 
     local statusMapQuery = |||
-      probe_success{
+      max by (instance) (probe_success{
         job=~"$job"
-      }
+      })
     ||| % $._config,
 
     local statusMapStatPanel =
@@ -229,10 +229,10 @@ local tsLegend = tsOptions.legend;
       stOptions.reduceOptions.withCalcs(['lastNotNull']),
 
     local uptimeQuery = |||
-      probe_success{
+      max by (instance) (probe_success{
         job=~"$job",
         instance=~"$instance"
-      }
+      })
     |||,
 
     local uptimeStatPanel =
@@ -289,10 +289,10 @@ local tsLegend = tsOptions.legend;
       ]),
 
     local probeSuccessQuery = |||
-      probe_success{
+      max by (instance) (probe_success{
         job=~"$job",
         instance=~"$instance"
-      }
+      })
     |||,
 
     local probeSuccessStatPanel =
@@ -320,10 +320,10 @@ local tsLegend = tsOptions.legend;
       ),
 
     local latestResponseCodeQuery = |||
-      probe_http_status_code{
+      max by (instance) (probe_http_status_code{
         job=~"$job",
         instance=~"$instance"
-      }
+      })
     |||,
 
     local latestResponseCodeStatPanel =
@@ -351,10 +351,10 @@ local tsLegend = tsOptions.legend;
       ]),
 
     local sslQuery = |||
-      probe_http_ssl{
+      max by (instance) (probe_http_ssl{
         job=~"$job",
         instance=~"$instance"
-      }
+      })
     |||,
 
     local sslStatPanel =
@@ -382,10 +382,10 @@ local tsLegend = tsOptions.legend;
       ]),
 
     local sslVersionQuery = |||
-      probe_tls_version_info{
+      max by (instance,version) (probe_tls_version_info{
         job=~"$job",
         instance=~"$instance"
-      }
+      })
     |||,
 
     local sslVersionStatPanel =
@@ -411,10 +411,10 @@ local tsLegend = tsOptions.legend;
       ]),
 
     local redirectsQuery = |||
-      probe_http_redirects{
+      max by (intance) (probe_http_redirects{
         job=~"$job",
         instance=~"$instance"
-      }
+      })
     |||,
 
     local redirectsStatPanel =
@@ -442,10 +442,10 @@ local tsLegend = tsOptions.legend;
       ),
 
     local httpVersionQuery = |||
-      probe_http_version{
+      max by (instance) (probe_http_version{
         job=~"$job",
         instance=~"$instance"
-      }
+      })
     |||,
 
     local httpVersionStatPanel =
@@ -465,10 +465,10 @@ local tsLegend = tsOptions.legend;
 
 
     local sslCertificateExpiryQuery = |||
-      probe_ssl_earliest_cert_expiry{
+      min by (instance) (probe_ssl_earliest_cert_expiry{
         job=~"$job",
         instance=~"$instance"
-      } - time()
+      } - time())
     |||,
 
     local sslCertificateExpiryStatPanel =
@@ -492,10 +492,10 @@ local tsLegend = tsOptions.legend;
       ]),
 
     local averageLatencyQuery = |||
-      probe_duration_seconds{
+      avg by (instance) (probe_duration_seconds{
         job=~"$job",
         instance=~"$instance"
-      }
+      })
     |||,
 
     local averageLatencyStatPanel =
@@ -512,10 +512,10 @@ local tsLegend = tsOptions.legend;
       stOptions.reduceOptions.withCalcs(['mean']),
 
     local averageDnsLookupQuery = |||
-      probe_dns_lookup_time_seconds{
+      avg by (instance) (probe_dns_lookup_time_seconds{
         job=~"$job",
         instance=~"$instance"
-      }
+      })
     |||,
 
     local averageDnsLookupStatPanel =

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -411,7 +411,7 @@ local tsLegend = tsOptions.legend;
       ]),
 
     local redirectsQuery = |||
-      max by (intance) (probe_http_redirects{
+      max by (instance) (probe_http_redirects{
         job=~"$job",
         instance=~"$instance"
       })

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -532,14 +532,22 @@ local tsLegend = tsOptions.legend;
       stOptions.reduceOptions.withCalcs(['mean']),
 
     local probeHttpDurationQuery = |||
-      sum(
-        probe_http_duration_seconds{
+      avg by (instance) (
+        sum without (phase) (
+          probe_http_duration_seconds{
+            job=~"$job",
+            instance=~"$instance"
+          }
+      ))
+    |||,
+    local probeTotalDurationQuery = |||
+      avg by (instance) (
+        probe_duration_seconds{
           job=~"$job",
           instance=~"$instance"
         }
-      ) by (instance)
+      )
     |||,
-    local probeTotalDurationQuery = std.strReplace(probeHttpDurationQuery, 'probe_http_duration_seconds', 'probe_duration_seconds'),
 
     local probeDurationTimeSeriesPanel =
       timeSeriesPanel.new(
@@ -577,7 +585,7 @@ local tsLegend = tsOptions.legend;
 
 
     local probeHttpPhaseDurationQuery = |||
-      sum(
+      avg(
         probe_http_duration_seconds{
           job=~"$job",
           instance=~"$instance"

--- a/dashboards_out/blackbox-exporter.json
+++ b/dashboards_out/blackbox-exporter.json
@@ -869,7 +869,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "avg by (instance) (\n  sum without (phase) (\n    probe_http_duration_seconds{\n      job=~\"$job\",\n      instance=~\"$instance\"\n    }\n))\n",
+               "expr": "sum by (instance) (\n  sum by (phase,instance) (\n    probe_http_duration_seconds{\n      job=~\"$job\",\n      instance=~\"$instance\"\n    }\n))\n",
                "legendFormat": "HTTP duration"
             },
             {

--- a/dashboards_out/blackbox-exporter.json
+++ b/dashboards_out/blackbox-exporter.json
@@ -77,7 +77,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "probe_success{\n  job=~\"$job\"\n}\n",
+               "expr": "max by (instance) (probe_success{\n  job=~\"$job\"\n})\n",
                "legendFormat": "{{instance}}"
             }
          ],
@@ -333,7 +333,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "probe_success{\n  job=~\"$job\",\n  instance=~\"$instance\"\n}\n"
+               "expr": "max by (instance) (probe_success{\n  job=~\"$job\",\n  instance=~\"$instance\"\n})\n"
             }
          ],
          "title": "Uptime",
@@ -440,7 +440,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "probe_success{\n  job=~\"$job\",\n  instance=~\"$instance\"\n}\n",
+               "expr": "max by (instance) (probe_success{\n  job=~\"$job\",\n  instance=~\"$instance\"\n})\n",
                "instant": true
             }
          ],
@@ -498,7 +498,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "probe_http_status_code{\n  job=~\"$job\",\n  instance=~\"$instance\"\n}\n",
+               "expr": "max by (instance) (probe_http_status_code{\n  job=~\"$job\",\n  instance=~\"$instance\"\n})\n",
                "instant": true
             }
          ],
@@ -552,7 +552,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "probe_http_ssl{\n  job=~\"$job\",\n  instance=~\"$instance\"\n}\n",
+               "expr": "max by (instance) (probe_http_ssl{\n  job=~\"$job\",\n  instance=~\"$instance\"\n})\n",
                "instant": true
             }
          ],
@@ -603,7 +603,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "probe_tls_version_info{\n  job=~\"$job\",\n  instance=~\"$instance\"\n}\n",
+               "expr": "max by (instance,version) (probe_tls_version_info{\n  job=~\"$job\",\n  instance=~\"$instance\"\n})\n",
                "instant": true,
                "legendFormat": "{{version}}"
             }
@@ -651,7 +651,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "probe_ssl_earliest_cert_expiry{\n  job=~\"$job\",\n  instance=~\"$instance\"\n} - time()\n"
+               "expr": "min by (instance) (probe_ssl_earliest_cert_expiry{\n  job=~\"$job\",\n  instance=~\"$instance\"\n} - time())\n"
             }
          ],
          "title": "SSL Certificate Expiry",
@@ -704,7 +704,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "probe_http_redirects{\n  job=~\"$job\",\n  instance=~\"$instance\"\n}\n",
+               "expr": "max by (intance) (probe_http_redirects{\n  job=~\"$job\",\n  instance=~\"$instance\"\n})\n",
                "instant": true
             }
          ],
@@ -742,7 +742,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "probe_http_version{\n  job=~\"$job\",\n  instance=~\"$instance\"\n}\n",
+               "expr": "max by (instance) (probe_http_version{\n  job=~\"$job\",\n  instance=~\"$instance\"\n})\n",
                "instant": true,
                "legendFormat": "{{version}}"
             }
@@ -781,7 +781,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "probe_duration_seconds{\n  job=~\"$job\",\n  instance=~\"$instance\"\n}\n"
+               "expr": "avg by (instance) (probe_duration_seconds{\n  job=~\"$job\",\n  instance=~\"$instance\"\n})\n"
             }
          ],
          "title": "Average Latency",
@@ -818,7 +818,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "probe_dns_lookup_time_seconds{\n  job=~\"$job\",\n  instance=~\"$instance\"\n}\n"
+               "expr": "avg by (instance) (probe_dns_lookup_time_seconds{\n  job=~\"$job\",\n  instance=~\"$instance\"\n})\n"
             }
          ],
          "title": "Average Latency",
@@ -869,7 +869,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum(\n  probe_http_duration_seconds{\n    job=~\"$job\",\n    instance=~\"$instance\"\n  }\n) by (instance)\n",
+               "expr": "avg by (instance) (\n  sum without (phase) (\n    probe_http_duration_seconds{\n      job=~\"$job\",\n      instance=~\"$instance\"\n    }\n))\n",
                "legendFormat": "HTTP duration"
             },
             {
@@ -877,7 +877,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum(\n  probe_duration_seconds{\n    job=~\"$job\",\n    instance=~\"$instance\"\n  }\n) by (instance)\n",
+               "expr": "avg by (instance) (\n  probe_duration_seconds{\n    job=~\"$job\",\n    instance=~\"$instance\"\n  }\n)\n",
                "legendFormat": "Total probe duration"
             }
          ],
@@ -932,7 +932,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum(\n  probe_http_duration_seconds{\n    job=~\"$job\",\n    instance=~\"$instance\"\n  }\n) by (phase)\n",
+               "expr": "avg(\n  probe_http_duration_seconds{\n    job=~\"$job\",\n    instance=~\"$instance\"\n  }\n) by (phase)\n",
                "legendFormat": "{{ phase }}"
             },
             {
@@ -940,7 +940,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum(\n  probe_icmp_duration_seconds{\n    job=~\"$job\",\n    instance=~\"$instance\"\n  }\n) by (phase)\n",
+               "expr": "avg(\n  probe_icmp_duration_seconds{\n    job=~\"$job\",\n    instance=~\"$instance\"\n  }\n) by (phase)\n",
                "legendFormat": "{{ phase }}"
             }
          ],

--- a/dashboards_out/blackbox-exporter.json
+++ b/dashboards_out/blackbox-exporter.json
@@ -869,7 +869,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum by (instance) (\n  sum by (phase,instance) (\n    probe_http_duration_seconds{\n      job=~\"$job\",\n      instance=~\"$instance\"\n    }\n))\n",
+               "expr": "sum by (instance) (\n  avg by (phase,instance) (\n    probe_http_duration_seconds{\n      job=~\"$job\",\n      instance=~\"$instance\"\n    }\n))\n",
                "legendFormat": "HTTP duration"
             },
             {

--- a/dashboards_out/blackbox-exporter.json
+++ b/dashboards_out/blackbox-exporter.json
@@ -704,7 +704,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "max by (intance) (probe_http_redirects{\n  job=~\"$job\",\n  instance=~\"$instance\"\n})\n",
+               "expr": "max by (instance) (probe_http_redirects{\n  job=~\"$job\",\n  instance=~\"$instance\"\n})\n",
                "instant": true
             }
          ],


### PR DESCRIPTION
This aggregates queries on the dashboard when there is more than one blackbox exporter is checking the same target(instance).   If there is only single exporter, then these aggregations wouldn't make any difference.