### PR TITLE
Add support for datasource filter regex

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -13,6 +13,9 @@
     // Default datasource name
     datasourceName: 'default',
 
+    // Datasource instance filter regex
+    datasourceFilterRegex: '',
+
     // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
     showMultiCluster: false,
     clusterLabel: 'cluster',

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -33,6 +33,7 @@ local tsLegend = tsOptions.legend;
         'datasource',
         'prometheus',
       ) +
+      datasource.withRegex($._config.datasourceFilterRegex) +
       datasource.generalOptions.withLabel('Data source') +
       {
         current: {

--- a/dashboards_out/blackbox-exporter.json
+++ b/dashboards_out/blackbox-exporter.json
@@ -964,6 +964,7 @@
             "label": "Data source",
             "name": "datasource",
             "query": "prometheus",
+            "regex": "",
             "type": "datasource"
          },
          {


### PR DESCRIPTION
Adds https://grafana.github.io/grafonnet/API/dashboard/variable.html#fn-datasourcewithregex to filter the datasources retrieved by the datasource variable.

Same as in [kubernetes-mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/config.libsonnet#L103)