### PR TITLE
feat: Add config to collapse the summary row

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -42,6 +42,9 @@
     // Severity for the low uptime alert
     blackboxProbeSslCertificateExpireSeverity: 'warning',
 
+    // UI config
+    summaryRowCollapsed: false,
+
     tags: ['blackbox-exporter', 'blackbox-exporter-mixin'],
   },
 }

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -701,7 +701,8 @@ local tsLegend = tsOptions.legend;
     local summaryRow =
       row.new(
         title='Summary'
-      ),
+      ) +
+      row.withCollapsed($._config.summaryRowCollapsed),
 
     local individualProbesRow =
       row.new(

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -702,7 +702,21 @@ local tsLegend = tsOptions.legend;
       row.new(
         title='Summary'
       ) +
-      row.withCollapsed($._config.summaryRowCollapsed),
+      row.withCollapsed($._config.summaryRowCollapsed) +
+      row.withPanels([
+          statusMapStatPanel +
+          statPanel.gridPos.withX(0) +
+          statPanel.gridPos.withY(1) +
+          statPanel.gridPos.withW(24) +
+          statPanel.gridPos.withH(5),
+        ] +
+        grid.makeGrid(
+          [probesStatPanel, probesSuccessStatPanel, probesSSLStatPanel, probeDurationStatPanel],
+          panelWidth=6,
+          panelHeight=4,
+          startY=6
+        )
+      ),
 
     local individualProbesRow =
       row.new(
@@ -730,18 +744,7 @@ local tsLegend = tsOptions.legend;
           row.gridPos.withY(0) +
           row.gridPos.withW(24) +
           row.gridPos.withH(1),
-          statusMapStatPanel +
-          statPanel.gridPos.withX(0) +
-          statPanel.gridPos.withY(1) +
-          statPanel.gridPos.withW(24) +
-          statPanel.gridPos.withH(5),
         ] +
-        grid.makeGrid(
-          [probesStatPanel, probesSuccessStatPanel, probesSSLStatPanel, probeDurationStatPanel],
-          panelWidth=6,
-          panelHeight=4,
-          startY=6
-        ) +
         [
           individualProbesRow +
           row.gridPos.withX(0) +

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -787,28 +787,6 @@ local tsLegend = tsOptions.legend;
       startY=6
     ),
 
-    local dashboardPanels =
-    [
-      summaryRow +
-      row.gridPos.withX(0) +
-      row.gridPos.withY(0) +
-      row.gridPos.withW(24) +
-      row.gridPos.withH(1)
-    ] +
-    summaryRowPanels +
-    individualProbes,
-
-    local dashboardPanelsWithSummaryRowCollapsed = [
-      summaryRow +
-      row.withCollapsed(true) +
-      row.gridPos.withX(0) +
-      row.gridPos.withY(0) +
-      row.gridPos.withW(24) +
-      row.gridPos.withH(1) +
-      row.withPanels(summaryRowPanels)
-    ] +
-    individualProbes,
-
     'blackbox-exporter.json':
       $._config.bypassDashboardValidation +
       dashboard.new(
@@ -823,7 +801,17 @@ local tsLegend = tsOptions.legend;
       dashboard.time.withTo('now') +
       dashboard.withVariables(variables) +
       dashboard.withPanels(
-          if $._config.summaryRowCollapsed then dashboardPanelsWithSummaryRowCollapsed else dashboardPanels
-        )
+        [
+          summaryRow +
+          row.gridPos.withX(0) +
+          row.gridPos.withY(0) +
+          row.gridPos.withW(24) +
+          row.gridPos.withH(1) +
+          row.withCollapsed($._config.summaryRowCollapsed) +
+          (if $._config.summaryRowCollapsed then row.withPanels(summaryRowPanels) else {})
+        ] +
+        (if $._config.summaryRowCollapsed then [] else summaryRowPanels) +
+        individualProbes
+      )
   },
 }

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -709,39 +709,23 @@ local tsLegend = tsOptions.legend;
       ) +
       row.withRepeat('instance'),
 
-    local dashboardPanels =
-    [
-      summaryRow +
-      row.gridPos.withX(0) +
-      row.gridPos.withY(0) +
-      row.gridPos.withW(24) +
-      row.gridPos.withH(1),
-      statusMapStatPanel +
-      statPanel.gridPos.withX(0) +
-      statPanel.gridPos.withY(1) +
-      statPanel.gridPos.withW(24) +
-      statPanel.gridPos.withH(5),
-    ] +
-    grid.makeGrid(
-      [probesStatPanel, probesSuccessStatPanel, probesSSLStatPanel, probeDurationStatPanel],
-      panelWidth=6,
-      panelHeight=4,
-      startY=6
-    ) +
-    [
+    // Set this to 0 for the flat layout, -9 for the collapsed layout
+    local yOffset = if $._config.summaryRowCollapsed then -9 else 0,
+
+    local individualProbes = [
       individualProbesRow +
       row.gridPos.withX(0) +
-      row.gridPos.withY(10) +
+      row.gridPos.withY(yOffset + 10) +
       row.gridPos.withW(24) +
       row.gridPos.withH(1),
       uptimeStatPanel +
       statPanel.gridPos.withX(0) +
-      statPanel.gridPos.withY(11) +
+      statPanel.gridPos.withY(yOffset + 11) +
       statPanel.gridPos.withW(6) +
       statPanel.gridPos.withH(4),
       uptime30dStatPanel +
       statPanel.gridPos.withX(0) +
-      statPanel.gridPos.withY(15) +
+      statPanel.gridPos.withY(yOffset + 15) +
       statPanel.gridPos.withW(6) +
       statPanel.gridPos.withH(4),
     ] +
@@ -749,18 +733,18 @@ local tsLegend = tsOptions.legend;
       [probeSuccessStatPanel, latestResponseCodeStatPanel],
       panelWidth=3,
       panelHeight=2,
-      startY=15
+      startY=yOffset + 15
     ) +
     grid.makeGrid(
       [sslStatPanel, sslVersionStatPanel],
       panelWidth=3,
       panelHeight=2,
-      startY=17
+      startY=yOffset + 17
     ) +
     [
       sslCertificateExpiryStatPanel +
       statPanel.gridPos.withX(0) +
-      statPanel.gridPos.withY(19) +
+      statPanel.gridPos.withY(yOffset + 19) +
       statPanel.gridPos.withW(6) +
       statPanel.gridPos.withH(2),
     ] +
@@ -768,26 +752,51 @@ local tsLegend = tsOptions.legend;
       [redirectsStatPanel, httpVersionStatPanel],
       panelWidth=3,
       panelHeight=2,
-      startY=22
+      startY=yOffset + 22
     ) +
     grid.makeGrid(
       [averageLatencyStatPanel, averageDnsLookupStatPanel],
       panelWidth=3,
       panelHeight=4,
-      startY=25
+      startY=yOffset + 25
     ) +
     [
       probeDurationTimeSeriesPanel +
       timeSeriesPanel.gridPos.withX(6) +
-      timeSeriesPanel.gridPos.withY(11) +
+      timeSeriesPanel.gridPos.withY(yOffset + 11) +
       timeSeriesPanel.gridPos.withW(18) +
       timeSeriesPanel.gridPos.withH(10),
       probePhaseTimeSeriesPanel +
       timeSeriesPanel.gridPos.withX(6) +
-      timeSeriesPanel.gridPos.withY(21) +
+      timeSeriesPanel.gridPos.withY(yOffset + 21) +
       timeSeriesPanel.gridPos.withW(18) +
       timeSeriesPanel.gridPos.withH(10),
     ],
+
+    local summaryRowPanels = [
+      statusMapStatPanel +
+      statPanel.gridPos.withX(0) +
+      statPanel.gridPos.withY(1) +
+      statPanel.gridPos.withW(24) +
+      statPanel.gridPos.withH(5)
+    ] +
+    grid.makeGrid(
+      [probesStatPanel, probesSuccessStatPanel, probesSSLStatPanel, probeDurationStatPanel],
+      panelWidth=6,
+      panelHeight=4,
+      startY=6
+    ),
+
+    local dashboardPanels =
+    [
+      summaryRow +
+      row.gridPos.withX(0) +
+      row.gridPos.withY(0) +
+      row.gridPos.withW(24) +
+      row.gridPos.withH(1)
+    ] +
+    summaryRowPanels +
+    individualProbes,
 
     local dashboardPanelsWithSummaryRowCollapsed = [
       summaryRow +
@@ -796,78 +805,9 @@ local tsLegend = tsOptions.legend;
       row.gridPos.withY(0) +
       row.gridPos.withW(24) +
       row.gridPos.withH(1) +
-      row.withPanels([
-        statusMapStatPanel +
-        statPanel.gridPos.withX(0) +
-        statPanel.gridPos.withY(1) +
-        statPanel.gridPos.withW(24) +
-        statPanel.gridPos.withH(5)
-      ] +
-      grid.makeGrid(
-        [probesStatPanel, probesSuccessStatPanel, probesSSLStatPanel, probeDurationStatPanel],
-        panelWidth=6,
-        panelHeight=4,
-        startY=6
-      )),
-      individualProbesRow +
-      row.gridPos.withX(0) +
-      row.gridPos.withY(1) +
-      row.gridPos.withW(24) +
-      row.gridPos.withH(1),
-      uptimeStatPanel +
-      statPanel.gridPos.withX(0) +
-      statPanel.gridPos.withY(2) +
-      statPanel.gridPos.withW(6) +
-      statPanel.gridPos.withH(4),
-      uptime30dStatPanel +
-      statPanel.gridPos.withX(0) +
-      statPanel.gridPos.withY(6) +
-      statPanel.gridPos.withW(6) +
-      statPanel.gridPos.withH(4),
+      row.withPanels(summaryRowPanels)
     ] +
-    grid.makeGrid(
-      [probeSuccessStatPanel, latestResponseCodeStatPanel],
-      panelWidth=3,
-      panelHeight=2,
-      startY=6
-    ) +
-    grid.makeGrid(
-      [sslStatPanel, sslVersionStatPanel],
-      panelWidth=3,
-      panelHeight=2,
-      startY=8
-    ) +
-    [
-      sslCertificateExpiryStatPanel +
-      statPanel.gridPos.withX(0) +
-      statPanel.gridPos.withY(10) +
-      statPanel.gridPos.withW(6) +
-      statPanel.gridPos.withH(2),
-    ] +
-    grid.makeGrid(
-      [redirectsStatPanel, httpVersionStatPanel],
-      panelWidth=3,
-      panelHeight=2,
-      startY=13
-    ) +
-    grid.makeGrid(
-      [averageLatencyStatPanel, averageDnsLookupStatPanel],
-      panelWidth=3,
-      panelHeight=4,
-      startY=16
-    ) +
-    [
-      probeDurationTimeSeriesPanel +
-      timeSeriesPanel.gridPos.withX(6) +
-      timeSeriesPanel.gridPos.withY(2) +
-      timeSeriesPanel.gridPos.withW(18) +
-      timeSeriesPanel.gridPos.withH(10),
-      probePhaseTimeSeriesPanel +
-      timeSeriesPanel.gridPos.withX(6) +
-      timeSeriesPanel.gridPos.withY(12) +
-      timeSeriesPanel.gridPos.withW(18) +
-      timeSeriesPanel.gridPos.withH(10),
-    ],
+    individualProbes,
 
     'blackbox-exporter.json':
       $._config.bypassDashboardValidation +

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -701,21 +701,6 @@ local tsLegend = tsOptions.legend;
     local summaryRow =
       row.new(
         title='Summary'
-      ) +
-      row.withCollapsed($._config.summaryRowCollapsed) +
-      row.withPanels([
-          statusMapStatPanel +
-          statPanel.gridPos.withX(0) +
-          statPanel.gridPos.withY(1) +
-          statPanel.gridPos.withW(24) +
-          statPanel.gridPos.withH(5),
-        ] +
-        grid.makeGrid(
-          [probesStatPanel, probesSuccessStatPanel, probesSSLStatPanel, probeDurationStatPanel],
-          panelWidth=6,
-          panelHeight=4,
-          startY=6
-        )
       ),
 
     local individualProbesRow =
@@ -723,6 +708,166 @@ local tsLegend = tsOptions.legend;
         title='$instance',
       ) +
       row.withRepeat('instance'),
+
+    local dashboardPanels =
+    [
+      summaryRow +
+      row.gridPos.withX(0) +
+      row.gridPos.withY(0) +
+      row.gridPos.withW(24) +
+      row.gridPos.withH(1),
+      statusMapStatPanel +
+      statPanel.gridPos.withX(0) +
+      statPanel.gridPos.withY(1) +
+      statPanel.gridPos.withW(24) +
+      statPanel.gridPos.withH(5),
+    ] +
+    grid.makeGrid(
+      [probesStatPanel, probesSuccessStatPanel, probesSSLStatPanel, probeDurationStatPanel],
+      panelWidth=6,
+      panelHeight=4,
+      startY=6
+    ) +
+    [
+      individualProbesRow +
+      row.gridPos.withX(0) +
+      row.gridPos.withY(10) +
+      row.gridPos.withW(24) +
+      row.gridPos.withH(1),
+      uptimeStatPanel +
+      statPanel.gridPos.withX(0) +
+      statPanel.gridPos.withY(11) +
+      statPanel.gridPos.withW(6) +
+      statPanel.gridPos.withH(4),
+      uptime30dStatPanel +
+      statPanel.gridPos.withX(0) +
+      statPanel.gridPos.withY(15) +
+      statPanel.gridPos.withW(6) +
+      statPanel.gridPos.withH(4),
+    ] +
+    grid.makeGrid(
+      [probeSuccessStatPanel, latestResponseCodeStatPanel],
+      panelWidth=3,
+      panelHeight=2,
+      startY=15
+    ) +
+    grid.makeGrid(
+      [sslStatPanel, sslVersionStatPanel],
+      panelWidth=3,
+      panelHeight=2,
+      startY=17
+    ) +
+    [
+      sslCertificateExpiryStatPanel +
+      statPanel.gridPos.withX(0) +
+      statPanel.gridPos.withY(19) +
+      statPanel.gridPos.withW(6) +
+      statPanel.gridPos.withH(2),
+    ] +
+    grid.makeGrid(
+      [redirectsStatPanel, httpVersionStatPanel],
+      panelWidth=3,
+      panelHeight=2,
+      startY=22
+    ) +
+    grid.makeGrid(
+      [averageLatencyStatPanel, averageDnsLookupStatPanel],
+      panelWidth=3,
+      panelHeight=4,
+      startY=25
+    ) +
+    [
+      probeDurationTimeSeriesPanel +
+      timeSeriesPanel.gridPos.withX(6) +
+      timeSeriesPanel.gridPos.withY(11) +
+      timeSeriesPanel.gridPos.withW(18) +
+      timeSeriesPanel.gridPos.withH(10),
+      probePhaseTimeSeriesPanel +
+      timeSeriesPanel.gridPos.withX(6) +
+      timeSeriesPanel.gridPos.withY(21) +
+      timeSeriesPanel.gridPos.withW(18) +
+      timeSeriesPanel.gridPos.withH(10),
+    ],
+
+    local dashboardPanelsWithSummaryRowCollapsed = [
+      summaryRow +
+      row.withCollapsed(true) +
+      row.gridPos.withX(0) +
+      row.gridPos.withY(0) +
+      row.gridPos.withW(24) +
+      row.gridPos.withH(1) +
+      row.withPanels([
+        statusMapStatPanel +
+        statPanel.gridPos.withX(0) +
+        statPanel.gridPos.withY(1) +
+        statPanel.gridPos.withW(24) +
+        statPanel.gridPos.withH(5)
+      ] +
+      grid.makeGrid(
+        [probesStatPanel, probesSuccessStatPanel, probesSSLStatPanel, probeDurationStatPanel],
+        panelWidth=6,
+        panelHeight=4,
+        startY=6
+      )),
+      individualProbesRow +
+      row.gridPos.withX(0) +
+      row.gridPos.withY(1) +
+      row.gridPos.withW(24) +
+      row.gridPos.withH(1),
+      uptimeStatPanel +
+      statPanel.gridPos.withX(0) +
+      statPanel.gridPos.withY(2) +
+      statPanel.gridPos.withW(6) +
+      statPanel.gridPos.withH(4),
+      uptime30dStatPanel +
+      statPanel.gridPos.withX(0) +
+      statPanel.gridPos.withY(6) +
+      statPanel.gridPos.withW(6) +
+      statPanel.gridPos.withH(4),
+    ] +
+    grid.makeGrid(
+      [probeSuccessStatPanel, latestResponseCodeStatPanel],
+      panelWidth=3,
+      panelHeight=2,
+      startY=6
+    ) +
+    grid.makeGrid(
+      [sslStatPanel, sslVersionStatPanel],
+      panelWidth=3,
+      panelHeight=2,
+      startY=8
+    ) +
+    [
+      sslCertificateExpiryStatPanel +
+      statPanel.gridPos.withX(0) +
+      statPanel.gridPos.withY(10) +
+      statPanel.gridPos.withW(6) +
+      statPanel.gridPos.withH(2),
+    ] +
+    grid.makeGrid(
+      [redirectsStatPanel, httpVersionStatPanel],
+      panelWidth=3,
+      panelHeight=2,
+      startY=13
+    ) +
+    grid.makeGrid(
+      [averageLatencyStatPanel, averageDnsLookupStatPanel],
+      panelWidth=3,
+      panelHeight=4,
+      startY=16
+    ) +
+    [
+      probeDurationTimeSeriesPanel +
+      timeSeriesPanel.gridPos.withX(6) +
+      timeSeriesPanel.gridPos.withY(2) +
+      timeSeriesPanel.gridPos.withW(18) +
+      timeSeriesPanel.gridPos.withH(10),
+      probePhaseTimeSeriesPanel +
+      timeSeriesPanel.gridPos.withX(6) +
+      timeSeriesPanel.gridPos.withY(12) +
+      timeSeriesPanel.gridPos.withW(18) +
+      timeSeriesPanel.gridPos.withH(10),
+    ],
 
     'blackbox-exporter.json':
       $._config.bypassDashboardValidation +
@@ -738,73 +883,7 @@ local tsLegend = tsOptions.legend;
       dashboard.time.withTo('now') +
       dashboard.withVariables(variables) +
       dashboard.withPanels(
-        [
-          summaryRow +
-          row.gridPos.withX(0) +
-          row.gridPos.withY(0) +
-          row.gridPos.withW(24) +
-          row.gridPos.withH(1),
-        ] +
-        [
-          individualProbesRow +
-          row.gridPos.withX(0) +
-          row.gridPos.withY(10) +
-          row.gridPos.withW(24) +
-          row.gridPos.withH(1),
-          uptimeStatPanel +
-          statPanel.gridPos.withX(0) +
-          statPanel.gridPos.withY(11) +
-          statPanel.gridPos.withW(6) +
-          statPanel.gridPos.withH(4),
-          uptime30dStatPanel +
-          statPanel.gridPos.withX(0) +
-          statPanel.gridPos.withY(15) +
-          statPanel.gridPos.withW(6) +
-          statPanel.gridPos.withH(4),
-        ] +
-        grid.makeGrid(
-          [probeSuccessStatPanel, latestResponseCodeStatPanel],
-          panelWidth=3,
-          panelHeight=2,
-          startY=15
-        ) +
-        grid.makeGrid(
-          [sslStatPanel, sslVersionStatPanel],
-          panelWidth=3,
-          panelHeight=2,
-          startY=17
-        ) +
-        [
-          sslCertificateExpiryStatPanel +
-          statPanel.gridPos.withX(0) +
-          statPanel.gridPos.withY(19) +
-          statPanel.gridPos.withW(6) +
-          statPanel.gridPos.withH(2),
-        ] +
-        grid.makeGrid(
-          [redirectsStatPanel, httpVersionStatPanel],
-          panelWidth=3,
-          panelHeight=2,
-          startY=22
-        ) +
-        grid.makeGrid(
-          [averageLatencyStatPanel, averageDnsLookupStatPanel],
-          panelWidth=3,
-          panelHeight=4,
-          startY=25
-        ) +
-        [
-          probeDurationTimeSeriesPanel +
-          timeSeriesPanel.gridPos.withX(6) +
-          timeSeriesPanel.gridPos.withY(11) +
-          timeSeriesPanel.gridPos.withW(18) +
-          timeSeriesPanel.gridPos.withH(10),
-          probePhaseTimeSeriesPanel +
-          timeSeriesPanel.gridPos.withX(6) +
-          timeSeriesPanel.gridPos.withY(21) +
-          timeSeriesPanel.gridPos.withW(18) +
-          timeSeriesPanel.gridPos.withH(10),
-        ]
-      ),
+          if $._config.summaryRowCollapsed then dashboardPanelsWithSummaryRowCollapsed else dashboardPanels
+        )
   },
 }

--- a/dashboards/dashboards.libsonnet
+++ b/dashboards/dashboards.libsonnet
@@ -712,80 +712,82 @@ local tsLegend = tsOptions.legend;
     // Set this to 0 for the flat layout, -9 for the collapsed layout
     local yOffset = if $._config.summaryRowCollapsed then -9 else 0,
 
-    local individualProbes = [
-      individualProbesRow +
-      row.gridPos.withX(0) +
-      row.gridPos.withY(yOffset + 10) +
-      row.gridPos.withW(24) +
-      row.gridPos.withH(1),
-      uptimeStatPanel +
-      statPanel.gridPos.withX(0) +
-      statPanel.gridPos.withY(yOffset + 11) +
-      statPanel.gridPos.withW(6) +
-      statPanel.gridPos.withH(4),
-      uptime30dStatPanel +
-      statPanel.gridPos.withX(0) +
-      statPanel.gridPos.withY(yOffset + 15) +
-      statPanel.gridPos.withW(6) +
-      statPanel.gridPos.withH(4),
-    ] +
-    grid.makeGrid(
-      [probeSuccessStatPanel, latestResponseCodeStatPanel],
-      panelWidth=3,
-      panelHeight=2,
-      startY=yOffset + 15
-    ) +
-    grid.makeGrid(
-      [sslStatPanel, sslVersionStatPanel],
-      panelWidth=3,
-      panelHeight=2,
-      startY=yOffset + 17
-    ) +
-    [
-      sslCertificateExpiryStatPanel +
-      statPanel.gridPos.withX(0) +
-      statPanel.gridPos.withY(yOffset + 19) +
-      statPanel.gridPos.withW(6) +
-      statPanel.gridPos.withH(2),
-    ] +
-    grid.makeGrid(
-      [redirectsStatPanel, httpVersionStatPanel],
-      panelWidth=3,
-      panelHeight=2,
-      startY=yOffset + 22
-    ) +
-    grid.makeGrid(
-      [averageLatencyStatPanel, averageDnsLookupStatPanel],
-      panelWidth=3,
-      panelHeight=4,
-      startY=yOffset + 25
-    ) +
-    [
-      probeDurationTimeSeriesPanel +
-      timeSeriesPanel.gridPos.withX(6) +
-      timeSeriesPanel.gridPos.withY(yOffset + 11) +
-      timeSeriesPanel.gridPos.withW(18) +
-      timeSeriesPanel.gridPos.withH(10),
-      probePhaseTimeSeriesPanel +
-      timeSeriesPanel.gridPos.withX(6) +
-      timeSeriesPanel.gridPos.withY(yOffset + 21) +
-      timeSeriesPanel.gridPos.withW(18) +
-      timeSeriesPanel.gridPos.withH(10),
-    ],
+    local individualProbes =
+      [
+        individualProbesRow +
+        row.gridPos.withX(0) +
+        row.gridPos.withY(yOffset + 10) +
+        row.gridPos.withW(24) +
+        row.gridPos.withH(1),
+        uptimeStatPanel +
+        statPanel.gridPos.withX(0) +
+        statPanel.gridPos.withY(yOffset + 11) +
+        statPanel.gridPos.withW(6) +
+        statPanel.gridPos.withH(4),
+        uptime30dStatPanel +
+        statPanel.gridPos.withX(0) +
+        statPanel.gridPos.withY(yOffset + 15) +
+        statPanel.gridPos.withW(6) +
+        statPanel.gridPos.withH(4),
+      ] +
+      grid.makeGrid(
+        [probeSuccessStatPanel, latestResponseCodeStatPanel],
+        panelWidth=3,
+        panelHeight=2,
+        startY=yOffset + 15
+      ) +
+      grid.makeGrid(
+        [sslStatPanel, sslVersionStatPanel],
+        panelWidth=3,
+        panelHeight=2,
+        startY=yOffset + 17
+      ) +
+      [
+        sslCertificateExpiryStatPanel +
+        statPanel.gridPos.withX(0) +
+        statPanel.gridPos.withY(yOffset + 19) +
+        statPanel.gridPos.withW(6) +
+        statPanel.gridPos.withH(2),
+      ] +
+      grid.makeGrid(
+        [redirectsStatPanel, httpVersionStatPanel],
+        panelWidth=3,
+        panelHeight=2,
+        startY=yOffset + 22
+      ) +
+      grid.makeGrid(
+        [averageLatencyStatPanel, averageDnsLookupStatPanel],
+        panelWidth=3,
+        panelHeight=4,
+        startY=yOffset + 25
+      ) +
+      [
+        probeDurationTimeSeriesPanel +
+        timeSeriesPanel.gridPos.withX(6) +
+        timeSeriesPanel.gridPos.withY(yOffset + 11) +
+        timeSeriesPanel.gridPos.withW(18) +
+        timeSeriesPanel.gridPos.withH(10),
+        probePhaseTimeSeriesPanel +
+        timeSeriesPanel.gridPos.withX(6) +
+        timeSeriesPanel.gridPos.withY(yOffset + 21) +
+        timeSeriesPanel.gridPos.withW(18) +
+        timeSeriesPanel.gridPos.withH(10),
+      ],
 
-    local summaryRowPanels = [
-      statusMapStatPanel +
-      statPanel.gridPos.withX(0) +
-      statPanel.gridPos.withY(1) +
-      statPanel.gridPos.withW(24) +
-      statPanel.gridPos.withH(5)
-    ] +
-    grid.makeGrid(
-      [probesStatPanel, probesSuccessStatPanel, probesSSLStatPanel, probeDurationStatPanel],
-      panelWidth=6,
-      panelHeight=4,
-      startY=6
-    ),
+    local summaryRowPanels =
+      [
+        statusMapStatPanel +
+        statPanel.gridPos.withX(0) +
+        statPanel.gridPos.withY(1) +
+        statPanel.gridPos.withW(24) +
+        statPanel.gridPos.withH(5),
+      ] +
+      grid.makeGrid(
+        [probesStatPanel, probesSuccessStatPanel, probesSSLStatPanel, probeDurationStatPanel],
+        panelWidth=6,
+        panelHeight=4,
+        startY=6
+      ),
 
     'blackbox-exporter.json':
       $._config.bypassDashboardValidation +
@@ -808,10 +810,10 @@ local tsLegend = tsOptions.legend;
           row.gridPos.withW(24) +
           row.gridPos.withH(1) +
           row.withCollapsed($._config.summaryRowCollapsed) +
-          (if $._config.summaryRowCollapsed then row.withPanels(summaryRowPanels) else {})
+          (if $._config.summaryRowCollapsed then row.withPanels(summaryRowPanels) else {}),
         ] +
         (if $._config.summaryRowCollapsed then [] else summaryRowPanels) +
         individualProbes
-      )
+      ),
   },
 }


### PR DESCRIPTION
This code change allows to configure `summaryRowCollapsed`. It allows the summary row to be collapsed if desired.